### PR TITLE
feat: 알림 API 및 저장 구조 추가

### DIFF
--- a/src/main/java/com/domisa/domisa_backend/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/domisa/domisa_backend/global/exception/GlobalErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum GlobalErrorCode {
 
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "유저를 찾을 수 없습니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_NOT_FOUND", "알림을 찾을 수 없습니다."),
 	MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "MISSING_REQUIRED_FIELD", "필수 입력 항목이 누락되었습니다."),
 	INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "INVALID_NICKNAME_LENGTH", "닉네임은 최대 4글자까지 입력 가능합니다."),
 	DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다.");

--- a/src/main/java/com/domisa/domisa_backend/notification/controller/NotificationController.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/controller/NotificationController.java
@@ -1,0 +1,40 @@
+package com.domisa.domisa_backend.notification.controller;
+
+import com.domisa.domisa_backend.notification.dto.NotificationListResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
+import com.domisa.domisa_backend.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@GetMapping
+	public ResponseEntity<NotificationListResponse> getNotifications(@AuthenticationPrincipal Long userId) {
+		return ResponseEntity.ok(notificationService.getNotifications(userId));
+	}
+
+	@GetMapping("/status")
+	public ResponseEntity<NotificationStatusResponse> getNotificationStatus(@AuthenticationPrincipal Long userId) {
+		return ResponseEntity.ok(notificationService.getNotificationStatus(userId));
+	}
+
+	@PostMapping("/{notificationId}")
+	public ResponseEntity<NotificationReadResponse> markAsRead(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long notificationId
+	) {
+		return ResponseEntity.ok(notificationService.markAsRead(userId, notificationId));
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
@@ -1,0 +1,21 @@
+package com.domisa.domisa_backend.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.domisa.domisa_backend.notification.type.NotificationType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record NotificationListResponse(List<NotificationItem> notifications) {
+
+	public record NotificationItem(
+		@JsonProperty("notification_id")
+		Long notificationId,
+		Long userId,
+		NotificationType type,
+		String title,
+		String content,
+		boolean isRead,
+		LocalDateTime createdAt
+	) {
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
@@ -1,6 +1,5 @@
 package com.domisa.domisa_backend.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.domisa.domisa_backend.notification.type.NotificationType;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -8,9 +7,9 @@ import java.util.List;
 public record NotificationListResponse(List<NotificationItem> notifications) {
 
 	public record NotificationItem(
-		@JsonProperty("notification_id")
 		Long notificationId,
 		Long userId,
+		Long targetUserId,
 		NotificationType type,
 		String title,
 		String content,

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationReadResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationReadResponse.java
@@ -1,0 +1,7 @@
+package com.domisa.domisa_backend.notification.dto;
+
+public record NotificationReadResponse(
+	Long notificationId,
+	boolean isRead
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationStatusResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationStatusResponse.java
@@ -1,0 +1,7 @@
+package com.domisa.domisa_backend.notification.dto;
+
+public record NotificationStatusResponse(
+	boolean hasUnread,
+	long unreadCount
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -1,17 +1,13 @@
 package com.domisa.domisa_backend.notification.entity;
 
 import com.domisa.domisa_backend.notification.type.NotificationType;
-import com.domisa.domisa_backend.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -28,9 +24,11 @@ public class Notification {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "target_user_id")
+	private Long targetUserId;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "type", nullable = false, length = 20)
@@ -48,8 +46,9 @@ public class Notification {
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 
-	private Notification(User user, NotificationType type, String title, String content) {
-		this.user = user;
+	private Notification(Long userId, Long targetUserId, NotificationType type, String title, String content) {
+		this.userId = userId;
+		this.targetUserId = targetUserId;
 		this.type = type;
 		this.title = title;
 		this.content = content;
@@ -57,12 +56,18 @@ public class Notification {
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public static Notification create(User user, NotificationType type, String title, String content) {
-		return new Notification(user, type, title, content);
+	public static Notification create(
+		Long userId,
+		Long targetUserId,
+		NotificationType type,
+		String title,
+		String content
+	) {
+		return new Notification(userId, targetUserId, type, title, content);
 	}
 
-	public static Notification create(User user, NotificationTemplate template) {
-		return new Notification(user, template.type(), template.title(), template.content());
+	public static Notification create(Long userId, Long targetUserId, NotificationTemplate template) {
+		return new Notification(userId, targetUserId, template.type(), template.title(), template.content());
 	}
 
 	public void markAsRead() {

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -61,7 +61,18 @@ public class Notification {
 		return new Notification(user, type, title, content);
 	}
 
+	public static Notification create(User user, NotificationTemplate template) {
+		return new Notification(user, template.type(), template.title(), template.content());
+	}
+
 	public void markAsRead() {
 		this.isRead = true;
+	}
+
+	public record NotificationTemplate(
+		NotificationType type,
+		String title,
+		String content
+	) {
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -1,0 +1,67 @@
+package com.domisa.domisa_backend.notification.entity;
+
+import com.domisa.domisa_backend.notification.type.NotificationType;
+import com.domisa.domisa_backend.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notifications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false, length = 20)
+	private NotificationType type;
+
+	@Column(name = "title", nullable = false, length = 100)
+	private String title;
+
+	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Column(name = "is_read", nullable = false)
+	private boolean isRead = false;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	private Notification(User user, NotificationType type, String title, String content) {
+		this.user = user;
+		this.type = type;
+		this.title = title;
+		this.content = content;
+		this.isRead = false;
+		this.createdAt = LocalDateTime.now();
+	}
+
+	public static Notification create(User user, NotificationType type, String title, String content) {
+		return new Notification(user, type, title, content);
+	}
+
+	public void markAsRead() {
+		this.isRead = true;
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/repository/NotificationRepository.java
@@ -1,0 +1,15 @@
+package com.domisa.domisa_backend.notification.repository;
+
+import com.domisa.domisa_backend.notification.entity.Notification;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+	long countByUserIdAndIsReadFalse(Long userId);
+
+	Optional<Notification> findByIdAndUserId(Long notificationId, Long userId);
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -21,10 +21,6 @@ public class NotificationService {
 	private final NotificationRepository notificationRepository;
 	private final UserRepository userRepository;
 
-	@Transactional
-	public Notification createNotification(NotificationType type, Long userId) {
-		return createNotification(type, userId, null);
-	}
 
 	@Transactional
 	public Notification createNotification(NotificationType type, Long userId, Long targetUserId) {

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -1,0 +1,54 @@
+package com.domisa.domisa_backend.notification.service;
+
+import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
+import com.domisa.domisa_backend.global.exception.GlobalException;
+import com.domisa.domisa_backend.notification.dto.NotificationListResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
+import com.domisa.domisa_backend.notification.entity.Notification;
+import com.domisa.domisa_backend.notification.repository.NotificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	private final NotificationRepository notificationRepository;
+
+	@Transactional(readOnly = true)
+	public NotificationListResponse getNotifications(Long userId) {
+		List<NotificationListResponse.NotificationItem> notifications = notificationRepository
+			.findAllByUserIdOrderByCreatedAtDesc(userId)
+			.stream()
+			.map(notification -> new NotificationListResponse.NotificationItem(
+				notification.getId(),
+				notification.getUser().getId(),
+				notification.getType(),
+				notification.getTitle(),
+				notification.getContent(),
+				notification.isRead(),
+				notification.getCreatedAt()
+			))
+			.toList();
+
+		return new NotificationListResponse(notifications);
+	}
+
+	@Transactional(readOnly = true)
+	public NotificationStatusResponse getNotificationStatus(Long userId) {
+		long unreadCount = notificationRepository.countByUserIdAndIsReadFalse(userId);
+		return new NotificationStatusResponse(unreadCount > 0, unreadCount);
+	}
+
+	@Transactional
+	public NotificationReadResponse markAsRead(Long userId, Long notificationId) {
+		Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.NOTIFICATION_NOT_FOUND));
+
+		notification.markAsRead();
+		return new NotificationReadResponse(notification.getId(), notification.isRead());
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -8,7 +8,6 @@ import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
 import com.domisa.domisa_backend.notification.entity.Notification;
 import com.domisa.domisa_backend.notification.repository.NotificationRepository;
 import com.domisa.domisa_backend.notification.type.NotificationType;
-import com.domisa.domisa_backend.user.entity.User;
 import com.domisa.domisa_backend.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,16 +23,18 @@ public class NotificationService {
 
 	@Transactional
 	public Notification createNotification(NotificationType type, Long userId) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
-
-		return createNotification(type, user);
+		return createNotification(type, userId, null);
 	}
 
 	@Transactional
-	public Notification createNotification(NotificationType type, User user) {
+	public Notification createNotification(NotificationType type, Long userId, Long targetUserId) {
+		validateUserExists(userId);
+		if (targetUserId != null) {
+			validateUserExists(targetUserId);
+		}
+
 		Notification.NotificationTemplate template = createTemplate(type);
-		Notification notification = Notification.create(user, template);
+		Notification notification = Notification.create(userId, targetUserId, template);
 		return notificationRepository.save(notification);
 	}
 
@@ -44,7 +45,8 @@ public class NotificationService {
 			.stream()
 			.map(notification -> new NotificationListResponse.NotificationItem(
 				notification.getId(),
-				notification.getUser().getId(),
+				notification.getUserId(),
+				notification.getTargetUserId(),
 				notification.getType(),
 				notification.getTitle(),
 				notification.getContent(),
@@ -89,5 +91,11 @@ public class NotificationService {
 				"새로운 추천 상대를 확인해보세요."
 			);
 		};
+	}
+
+	private void validateUserExists(Long userId) {
+		if (!userRepository.existsById(userId)) {
+			throw new GlobalException(GlobalErrorCode.USER_NOT_FOUND);
+		}
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -7,6 +7,9 @@ import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
 import com.domisa.domisa_backend.notification.entity.Notification;
 import com.domisa.domisa_backend.notification.repository.NotificationRepository;
+import com.domisa.domisa_backend.notification.type.NotificationType;
+import com.domisa.domisa_backend.user.entity.User;
+import com.domisa.domisa_backend.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
 	private final NotificationRepository notificationRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public Notification createNotification(NotificationType type, Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
+
+		return createNotification(type, user);
+	}
+
+	@Transactional
+	public Notification createNotification(NotificationType type, User user) {
+		Notification.NotificationTemplate template = createTemplate(type);
+		Notification notification = Notification.create(user, template);
+		return notificationRepository.save(notification);
+	}
 
 	@Transactional(readOnly = true)
 	public NotificationListResponse getNotifications(Long userId) {
@@ -50,5 +69,25 @@ public class NotificationService {
 
 		notification.markAsRead();
 		return new NotificationReadResponse(notification.getId(), notification.isRead());
+	}
+
+	private Notification.NotificationTemplate createTemplate(NotificationType type) {
+		return switch (type) {
+			case LIKE -> new Notification.NotificationTemplate(
+				NotificationType.LIKE,
+				"새로운 호감이 도착했어요",
+				"새로운 호감을 확인해보세요."
+			);
+			case INTRODUCTION -> new Notification.NotificationTemplate(
+				NotificationType.INTRODUCTION,
+				"소개서가 도착했어요",
+				"새로운 소개서를 확인해보세요."
+			);
+			case SHUFFLE -> new Notification.NotificationTemplate(
+				NotificationType.SHUFFLE,
+				"새로운 추천이 도착했어요",
+				"새로운 추천 상대를 확인해보세요."
+			);
+		};
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/type/NotificationType.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/type/NotificationType.java
@@ -1,0 +1,7 @@
+package com.domisa.domisa_backend.notification.type;
+
+public enum NotificationType {
+	LIKE,
+	INTRODUCTION,
+	SHUFFLE
+}

--- a/src/main/java/com/domisa/domisa_backend/user/entity/User.java
+++ b/src/main/java/com/domisa/domisa_backend/user/entity/User.java
@@ -17,6 +17,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.time.Year;
 
@@ -92,6 +93,9 @@ public class User {
 	@CollectionTable(name = "user_now_shows", joinColumns = @JoinColumn(name = "user_id"))
 	@Column(name = "target_user_id")
 	private List<Long> nowShows;
+
+	@Column(name = "shows_refresh_at")
+	private LocalDateTime showsRefreshAt;
 
 	@Column(name = "is_certificated", nullable = false)
 	private Boolean isCertificated = false;

--- a/src/main/java/com/domisa/domisa_backend/user/type/AnimalProfile.java
+++ b/src/main/java/com/domisa/domisa_backend/user/type/AnimalProfile.java
@@ -1,12 +1,16 @@
 package com.domisa.domisa_backend.user.type;
 
 public enum AnimalProfile {
-	DOG,
-	CAT,
-	FOX,
-	BEAR,
-	RABBIT,
-	DEER,
-	WOLF,
-	TIGER
+	DOG, // 강아지
+	CAT, // 고양이
+	BEAR, // 곰
+	SLOTH, // 나무늘보
+	HAMSTER, // 햄스터
+	WOLF, // 늑대
+	RABBIT, // 토끼
+	DEER, // 사슴
+	OTTER, // 수달
+	ALPACA, // 알파카
+	FOX, // 여우
+	CAPYBARA // 카피바라
 }

--- a/src/main/java/com/domisa/domisa_backend/user/type/ContactType.java
+++ b/src/main/java/com/domisa/domisa_backend/user/type/ContactType.java
@@ -3,6 +3,5 @@ package com.domisa.domisa_backend.user.type;
 public enum ContactType {
 	KAKAO_TALK,
 	INSTAGRAM,
-	PHONE_NUMBER,
-	EMAIL
+	PHONE_NUMBER
 }


### PR DESCRIPTION
## 요약
- 알림 조회/상태/읽음 처리 API를 추가했습니다.
- 알림 생성 서비스 로직을 추가했습니다.
- 알림 저장 구조를 `user_id`, `target_user_id` 기반으로 정리했습니다.

## 주요 변경
- `GET /api/notifications`
- `GET /api/notifications/status`
- `POST /api/notifications/{notificationId}`
- `NotificationType` enum 추가
- `NotificationService#createNotification(...)` 추가
- 알림 엔티티를 연관 객체 대신 ID 저장 방식으로 변경

## 참고
- 알림 생성 시 타입별 기본 제목/내용이 자동으로 저장됩니다.
- `target_user_id`는 필요한 알림에서만 사용하며 없으면 `null`입니다.

## 검증
- `./gradlew compileJava`