### PR TITLE
refactor: 사용자 상태를 연관 엔티티 기반으로 정리

### DIFF
--- a/src/main/java/com/domisa/domisa_backend/auth/service/AuthService.java
+++ b/src/main/java/com/domisa/domisa_backend/auth/service/AuthService.java
@@ -45,7 +45,7 @@ public class AuthService {
 		return new LoginResponse(
 			new LoginResponse.StatusDto(
 				user.getIsRegistered(),
-				user.getHasIntroduction(),
+				user.hasIntroduction(),
 				user.hasCard()
 			)
 		);

--- a/src/main/java/com/domisa/domisa_backend/auth/service/AuthService.java
+++ b/src/main/java/com/domisa/domisa_backend/auth/service/AuthService.java
@@ -46,7 +46,7 @@ public class AuthService {
 			new LoginResponse.StatusDto(
 				user.getIsRegistered(),
 				user.getHasIntroduction(),
-				user.getIsProfileCompleted()
+				user.hasCard()
 			)
 		);
 	}

--- a/src/main/java/com/domisa/domisa_backend/card/entity/Card.java
+++ b/src/main/java/com/domisa/domisa_backend/card/entity/Card.java
@@ -1,0 +1,43 @@
+package com.domisa.domisa_backend.card.entity;
+
+import com.domisa.domisa_backend.user.entity.User;
+import com.domisa.domisa_backend.user.type.Mbti;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "cards")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Card {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false, unique = true)
+	private User user;
+
+	@Column(name = "ideal_type")
+	private String idealType;
+
+	@Column(name = "dating_style")
+	private String datingStyle;
+
+	@Column(name = "mbti", length = 20)
+	@Enumerated(EnumType.STRING)
+	private Mbti mbti;
+}

--- a/src/main/java/com/domisa/domisa_backend/card/repository/CardRepository.java
+++ b/src/main/java/com/domisa/domisa_backend/card/repository/CardRepository.java
@@ -1,0 +1,10 @@
+package com.domisa.domisa_backend.card.repository;
+
+import com.domisa.domisa_backend.card.entity.Card;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardRepository extends JpaRepository<Card, Long> {
+
+	Optional<Card> findByUserId(Long userId);
+}

--- a/src/main/java/com/domisa/domisa_backend/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/domisa/domisa_backend/global/exception/GlobalErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum GlobalErrorCode {
 
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "유저를 찾을 수 없습니다."),
+	NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_NOT_FOUND", "알림을 찾을 수 없습니다."),
 	MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "MISSING_REQUIRED_FIELD", "필수 입력 항목이 누락되었습니다."),
 	INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "INVALID_NICKNAME_LENGTH", "닉네임은 최대 4글자까지 입력 가능합니다."),
 	DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다.");

--- a/src/main/java/com/domisa/domisa_backend/introduction/entity/Introduction.java
+++ b/src/main/java/com/domisa/domisa_backend/introduction/entity/Introduction.java
@@ -1,0 +1,45 @@
+package com.domisa.domisa_backend.introduction.entity;
+
+import com.domisa.domisa_backend.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "introductions")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Introduction {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "q1", columnDefinition = "TEXT")
+	private String q1;
+
+	@Column(name = "q2", columnDefinition = "TEXT")
+	private String q2;
+
+	@Column(name = "q3", columnDefinition = "TEXT")
+	private String q3;
+
+	@Column(name = "introducer_id", nullable = false)
+	private Long introducerId;
+
+	@OneToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "participant_id", nullable = false, unique = true)
+	private User participant;
+
+	@Column(name = "link_code")
+	private String linkCode;
+}

--- a/src/main/java/com/domisa/domisa_backend/introduction/repository/IntroductionRepository.java
+++ b/src/main/java/com/domisa/domisa_backend/introduction/repository/IntroductionRepository.java
@@ -1,0 +1,10 @@
+package com.domisa.domisa_backend.introduction.repository;
+
+import com.domisa.domisa_backend.introduction.entity.Introduction;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IntroductionRepository extends JpaRepository<Introduction, Long> {
+
+	Optional<Introduction> findByParticipantId(Long participantId);
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/controller/NotificationController.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/controller/NotificationController.java
@@ -1,0 +1,40 @@
+package com.domisa.domisa_backend.notification.controller;
+
+import com.domisa.domisa_backend.notification.dto.NotificationListResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
+import com.domisa.domisa_backend.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@GetMapping
+	public ResponseEntity<NotificationListResponse> getNotifications(@AuthenticationPrincipal Long userId) {
+		return ResponseEntity.ok(notificationService.getNotifications(userId));
+	}
+
+	@GetMapping("/status")
+	public ResponseEntity<NotificationStatusResponse> getNotificationStatus(@AuthenticationPrincipal Long userId) {
+		return ResponseEntity.ok(notificationService.getNotificationStatus(userId));
+	}
+
+	@PostMapping("/{notificationId}")
+	public ResponseEntity<NotificationReadResponse> markAsRead(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long notificationId
+	) {
+		return ResponseEntity.ok(notificationService.markAsRead(userId, notificationId));
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
@@ -1,0 +1,21 @@
+package com.domisa.domisa_backend.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.domisa.domisa_backend.notification.type.NotificationType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record NotificationListResponse(List<NotificationItem> notifications) {
+
+	public record NotificationItem(
+		@JsonProperty("notification_id")
+		Long notificationId,
+		Long userId,
+		NotificationType type,
+		String title,
+		String content,
+		boolean isRead,
+		LocalDateTime createdAt
+	) {
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
@@ -1,6 +1,5 @@
 package com.domisa.domisa_backend.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.domisa.domisa_backend.notification.type.NotificationType;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -8,9 +7,9 @@ import java.util.List;
 public record NotificationListResponse(List<NotificationItem> notifications) {
 
 	public record NotificationItem(
-		@JsonProperty("notification_id")
 		Long notificationId,
 		Long userId,
+		Long targetUserId,
 		NotificationType type,
 		String title,
 		String content,

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationReadResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationReadResponse.java
@@ -1,0 +1,7 @@
+package com.domisa.domisa_backend.notification.dto;
+
+public record NotificationReadResponse(
+	Long notificationId,
+	boolean isRead
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationStatusResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationStatusResponse.java
@@ -1,0 +1,7 @@
+package com.domisa.domisa_backend.notification.dto;
+
+public record NotificationStatusResponse(
+	boolean hasUnread,
+	long unreadCount
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -1,17 +1,13 @@
 package com.domisa.domisa_backend.notification.entity;
 
 import com.domisa.domisa_backend.notification.type.NotificationType;
-import com.domisa.domisa_backend.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -28,9 +24,11 @@ public class Notification {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY, optional = false)
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "target_user_id")
+	private Long targetUserId;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "type", nullable = false, length = 20)
@@ -48,8 +46,9 @@ public class Notification {
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 
-	private Notification(User user, NotificationType type, String title, String content) {
-		this.user = user;
+	private Notification(Long userId, Long targetUserId, NotificationType type, String title, String content) {
+		this.userId = userId;
+		this.targetUserId = targetUserId;
 		this.type = type;
 		this.title = title;
 		this.content = content;
@@ -57,12 +56,18 @@ public class Notification {
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public static Notification create(User user, NotificationType type, String title, String content) {
-		return new Notification(user, type, title, content);
+	public static Notification create(
+		Long userId,
+		Long targetUserId,
+		NotificationType type,
+		String title,
+		String content
+	) {
+		return new Notification(userId, targetUserId, type, title, content);
 	}
 
-	public static Notification create(User user, NotificationTemplate template) {
-		return new Notification(user, template.type(), template.title(), template.content());
+	public static Notification create(Long userId, Long targetUserId, NotificationTemplate template) {
+		return new Notification(userId, targetUserId, template.type(), template.title(), template.content());
 	}
 
 	public void markAsRead() {

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -61,7 +61,18 @@ public class Notification {
 		return new Notification(user, type, title, content);
 	}
 
+	public static Notification create(User user, NotificationTemplate template) {
+		return new Notification(user, template.type(), template.title(), template.content());
+	}
+
 	public void markAsRead() {
 		this.isRead = true;
+	}
+
+	public record NotificationTemplate(
+		NotificationType type,
+		String title,
+		String content
+	) {
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -1,0 +1,67 @@
+package com.domisa.domisa_backend.notification.entity;
+
+import com.domisa.domisa_backend.notification.type.NotificationType;
+import com.domisa.domisa_backend.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "notifications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", nullable = false, length = 20)
+	private NotificationType type;
+
+	@Column(name = "title", nullable = false, length = 100)
+	private String title;
+
+	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Column(name = "is_read", nullable = false)
+	private boolean isRead = false;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	private Notification(User user, NotificationType type, String title, String content) {
+		this.user = user;
+		this.type = type;
+		this.title = title;
+		this.content = content;
+		this.isRead = false;
+		this.createdAt = LocalDateTime.now();
+	}
+
+	public static Notification create(User user, NotificationType type, String title, String content) {
+		return new Notification(user, type, title, content);
+	}
+
+	public void markAsRead() {
+		this.isRead = true;
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/repository/NotificationRepository.java
@@ -1,0 +1,15 @@
+package com.domisa.domisa_backend.notification.repository;
+
+import com.domisa.domisa_backend.notification.entity.Notification;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+	long countByUserIdAndIsReadFalse(Long userId);
+
+	Optional<Notification> findByIdAndUserId(Long notificationId, Long userId);
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -21,10 +21,6 @@ public class NotificationService {
 	private final NotificationRepository notificationRepository;
 	private final UserRepository userRepository;
 
-	@Transactional
-	public Notification createNotification(NotificationType type, Long userId) {
-		return createNotification(type, userId, null);
-	}
 
 	@Transactional
 	public Notification createNotification(NotificationType type, Long userId, Long targetUserId) {

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -1,0 +1,54 @@
+package com.domisa.domisa_backend.notification.service;
+
+import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
+import com.domisa.domisa_backend.global.exception.GlobalException;
+import com.domisa.domisa_backend.notification.dto.NotificationListResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
+import com.domisa.domisa_backend.notification.entity.Notification;
+import com.domisa.domisa_backend.notification.repository.NotificationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	private final NotificationRepository notificationRepository;
+
+	@Transactional(readOnly = true)
+	public NotificationListResponse getNotifications(Long userId) {
+		List<NotificationListResponse.NotificationItem> notifications = notificationRepository
+			.findAllByUserIdOrderByCreatedAtDesc(userId)
+			.stream()
+			.map(notification -> new NotificationListResponse.NotificationItem(
+				notification.getId(),
+				notification.getUser().getId(),
+				notification.getType(),
+				notification.getTitle(),
+				notification.getContent(),
+				notification.isRead(),
+				notification.getCreatedAt()
+			))
+			.toList();
+
+		return new NotificationListResponse(notifications);
+	}
+
+	@Transactional(readOnly = true)
+	public NotificationStatusResponse getNotificationStatus(Long userId) {
+		long unreadCount = notificationRepository.countByUserIdAndIsReadFalse(userId);
+		return new NotificationStatusResponse(unreadCount > 0, unreadCount);
+	}
+
+	@Transactional
+	public NotificationReadResponse markAsRead(Long userId, Long notificationId) {
+		Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.NOTIFICATION_NOT_FOUND));
+
+		notification.markAsRead();
+		return new NotificationReadResponse(notification.getId(), notification.isRead());
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -8,7 +8,6 @@ import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
 import com.domisa.domisa_backend.notification.entity.Notification;
 import com.domisa.domisa_backend.notification.repository.NotificationRepository;
 import com.domisa.domisa_backend.notification.type.NotificationType;
-import com.domisa.domisa_backend.user.entity.User;
 import com.domisa.domisa_backend.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,16 +23,18 @@ public class NotificationService {
 
 	@Transactional
 	public Notification createNotification(NotificationType type, Long userId) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
-
-		return createNotification(type, user);
+		return createNotification(type, userId, null);
 	}
 
 	@Transactional
-	public Notification createNotification(NotificationType type, User user) {
+	public Notification createNotification(NotificationType type, Long userId, Long targetUserId) {
+		validateUserExists(userId);
+		if (targetUserId != null) {
+			validateUserExists(targetUserId);
+		}
+
 		Notification.NotificationTemplate template = createTemplate(type);
-		Notification notification = Notification.create(user, template);
+		Notification notification = Notification.create(userId, targetUserId, template);
 		return notificationRepository.save(notification);
 	}
 
@@ -44,7 +45,8 @@ public class NotificationService {
 			.stream()
 			.map(notification -> new NotificationListResponse.NotificationItem(
 				notification.getId(),
-				notification.getUser().getId(),
+				notification.getUserId(),
+				notification.getTargetUserId(),
 				notification.getType(),
 				notification.getTitle(),
 				notification.getContent(),
@@ -89,5 +91,11 @@ public class NotificationService {
 				"새로운 추천 상대를 확인해보세요."
 			);
 		};
+	}
+
+	private void validateUserExists(Long userId) {
+		if (!userRepository.existsById(userId)) {
+			throw new GlobalException(GlobalErrorCode.USER_NOT_FOUND);
+		}
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -7,6 +7,9 @@ import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
 import com.domisa.domisa_backend.notification.entity.Notification;
 import com.domisa.domisa_backend.notification.repository.NotificationRepository;
+import com.domisa.domisa_backend.notification.type.NotificationType;
+import com.domisa.domisa_backend.user.entity.User;
+import com.domisa.domisa_backend.user.repository.UserRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
 	private final NotificationRepository notificationRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public Notification createNotification(NotificationType type, Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
+
+		return createNotification(type, user);
+	}
+
+	@Transactional
+	public Notification createNotification(NotificationType type, User user) {
+		Notification.NotificationTemplate template = createTemplate(type);
+		Notification notification = Notification.create(user, template);
+		return notificationRepository.save(notification);
+	}
 
 	@Transactional(readOnly = true)
 	public NotificationListResponse getNotifications(Long userId) {
@@ -50,5 +69,25 @@ public class NotificationService {
 
 		notification.markAsRead();
 		return new NotificationReadResponse(notification.getId(), notification.isRead());
+	}
+
+	private Notification.NotificationTemplate createTemplate(NotificationType type) {
+		return switch (type) {
+			case LIKE -> new Notification.NotificationTemplate(
+				NotificationType.LIKE,
+				"새로운 호감이 도착했어요",
+				"새로운 호감을 확인해보세요."
+			);
+			case INTRODUCTION -> new Notification.NotificationTemplate(
+				NotificationType.INTRODUCTION,
+				"소개서가 도착했어요",
+				"새로운 소개서를 확인해보세요."
+			);
+			case SHUFFLE -> new Notification.NotificationTemplate(
+				NotificationType.SHUFFLE,
+				"새로운 추천이 도착했어요",
+				"새로운 추천 상대를 확인해보세요."
+			);
+		};
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/type/NotificationType.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/type/NotificationType.java
@@ -1,0 +1,7 @@
+package com.domisa.domisa_backend.notification.type;
+
+public enum NotificationType {
+	LIKE,
+	INTRODUCTION,
+	SHUFFLE
+}

--- a/src/main/java/com/domisa/domisa_backend/profile/service/ProfileService.java
+++ b/src/main/java/com/domisa/domisa_backend/profile/service/ProfileService.java
@@ -34,14 +34,13 @@ public class ProfileService {
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
 
-		user.registerProfile(
-			request.nickName(),
-			request.gender(),
-			request.birthYear(),
-			request.animalProfile(),
-			request.contact(),
-			request.inviteCode()
-		);
+		user.setNickname(request.nickName());
+		user.setGender(request.gender());
+		user.setBirthYear(request.birthYear());
+		user.setAnimalProfile(request.animalProfile());
+		user.setContact(request.contact());
+		user.setInviteCode(request.inviteCode());
+		user.setIsRegistered(true);
 
 		return Map.of("userId", user.getId());
 	}

--- a/src/main/java/com/domisa/domisa_backend/user/entity/User.java
+++ b/src/main/java/com/domisa/domisa_backend/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.domisa.domisa_backend.user.entity;
 
 import com.domisa.domisa_backend.card.entity.Card;
+import com.domisa.domisa_backend.introduction.entity.Introduction;
 import com.domisa.domisa_backend.user.type.AnimalProfile;
 import com.domisa.domisa_backend.user.type.ContactType;
 import jakarta.persistence.CollectionTable;
@@ -68,6 +69,9 @@ public class User {
 	@OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
 	private Card card;
 
+	@OneToOne(mappedBy = "participant", fetch = FetchType.LAZY)
+	private Introduction introduction;
+
 	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "user_my_blurs", joinColumns = @JoinColumn(name = "user_id"))
 	@Column(name = "target_user_id")
@@ -99,9 +103,6 @@ public class User {
 
 	@Column(name = "is_registered", nullable = false)
 	private Boolean isRegistered = false;
-
-	@Column(name = "has_introduction", nullable = false)
-	private Boolean hasIntroduction = false;
 
 	@Column(name = "profile_image_sequence", nullable = false)
 	private Long profileImageSequence = 0L;
@@ -155,6 +156,10 @@ public class User {
 
 	public boolean hasCard() {
 		return card != null;
+	}
+
+	public boolean hasIntroduction() {
+		return introduction != null;
 	}
 
 }

--- a/src/main/java/com/domisa/domisa_backend/user/entity/User.java
+++ b/src/main/java/com/domisa/domisa_backend/user/entity/User.java
@@ -1,8 +1,8 @@
 package com.domisa.domisa_backend.user.entity;
 
+import com.domisa.domisa_backend.card.entity.Card;
 import com.domisa.domisa_backend.user.type.AnimalProfile;
 import com.domisa.domisa_backend.user.type.ContactType;
-import com.domisa.domisa_backend.user.type.Mbti;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -14,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.*;
 
@@ -54,10 +55,6 @@ public class User {
 	@Column(name = "cookies", nullable = false)
 	private Long cookies = 0L;
 
-	@Column(name = "mbti", length = 20)
-	@Enumerated(EnumType.STRING)
-	private Mbti mbti;
-
 	@Column(name = "contact", length = 30)
 	private String contact;
 
@@ -68,11 +65,8 @@ public class User {
 	@Column(name = "invite_code", length = 20)
 	private String inviteCode;
 
-	@Column(name = "ideal_type")
-	private String idealType;
-
-	@Column(name = "dating_style")
-	private String datingStyle;
+	@OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+	private Card card;
 
 	@ElementCollection(fetch = FetchType.LAZY)
 	@CollectionTable(name = "user_my_blurs", joinColumns = @JoinColumn(name = "user_id"))
@@ -109,9 +103,6 @@ public class User {
 	@Column(name = "has_introduction", nullable = false)
 	private Boolean hasIntroduction = false;
 
-	@Column(name = "is_profile_completed", nullable = false)
-	private Boolean isProfileCompleted = false;
-
 	@Column(name = "profile_image_sequence", nullable = false)
 	private Long profileImageSequence = 0L;
 
@@ -142,7 +133,6 @@ public class User {
 		this.contact = contact;
 		this.inviteCode = inviteCode;
 		this.isRegistered = true;
-		this.isProfileCompleted = true;
 	}
 
 	public boolean hasProfileImage() {
@@ -161,6 +151,10 @@ public class User {
 			return null;
 		}
 		return gender ? "남" : "여";
+	}
+
+	public boolean hasCard() {
+		return card != null;
 	}
 
 }

--- a/src/main/java/com/domisa/domisa_backend/user/entity/User.java
+++ b/src/main/java/com/domisa/domisa_backend/user/entity/User.java
@@ -17,6 +17,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.time.Year;
 
@@ -92,6 +93,9 @@ public class User {
 	@CollectionTable(name = "user_now_shows", joinColumns = @JoinColumn(name = "user_id"))
 	@Column(name = "target_user_id")
 	private List<Long> nowShows;
+
+	@Column(name = "shows_refresh_at")
+	private LocalDateTime showsRefreshAt;
 
 	@Column(name = "is_certificated", nullable = false)
 	private Boolean isCertificated = false;

--- a/src/main/java/com/domisa/domisa_backend/user/entity/User.java
+++ b/src/main/java/com/domisa/domisa_backend/user/entity/User.java
@@ -119,23 +119,6 @@ public class User {
 		return new User(kakaoId);
 	}
 
-	public void registerProfile(
-		String nickname,
-		Boolean gender,
-		Long birthYear,
-		AnimalProfile animalProfile,
-		String contact,
-		String inviteCode
-	) {
-		this.nickname = nickname;
-		this.gender = gender;
-		this.birthYear = birthYear;
-		this.animalProfile = animalProfile;
-		this.contact = contact;
-		this.inviteCode = inviteCode;
-		this.isRegistered = true;
-	}
-
 	public boolean hasProfileImage() {
 		return profileImageObjectKey != null && !profileImageObjectKey.isBlank();
 	}

--- a/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
+++ b/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
 			),
 			new UserMeResponse.StatusDto(
 				user.getIsRegistered(),
-				user.getHasIntroduction(),
+				user.hasIntroduction(),
 				user.hasCard()
 			)
 		);

--- a/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
+++ b/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
 			new UserMeResponse.StatusDto(
 				user.getIsRegistered(),
 				user.getHasIntroduction(),
-				user.getIsProfileCompleted()
+				user.hasCard()
 			)
 		);
 	}

--- a/src/main/java/com/domisa/domisa_backend/user/type/AnimalProfile.java
+++ b/src/main/java/com/domisa/domisa_backend/user/type/AnimalProfile.java
@@ -1,12 +1,16 @@
 package com.domisa.domisa_backend.user.type;
 
 public enum AnimalProfile {
-	DOG,
-	CAT,
-	FOX,
-	BEAR,
-	RABBIT,
-	DEER,
-	WOLF,
-	TIGER
+	DOG, // 강아지
+	CAT, // 고양이
+	BEAR, // 곰
+	SLOTH, // 나무늘보
+	HAMSTER, // 햄스터
+	WOLF, // 늑대
+	RABBIT, // 토끼
+	DEER, // 사슴
+	OTTER, // 수달
+	ALPACA, // 알파카
+	FOX, // 여우
+	CAPYBARA // 카피바라
 }

--- a/src/main/java/com/domisa/domisa_backend/user/type/ContactType.java
+++ b/src/main/java/com/domisa/domisa_backend/user/type/ContactType.java
@@ -3,6 +3,5 @@ package com.domisa.domisa_backend.user.type;
 public enum ContactType {
 	KAKAO_TALK,
 	INSTAGRAM,
-	PHONE_NUMBER,
-	EMAIL
+	PHONE_NUMBER
 }


### PR DESCRIPTION
## 요약
- 사용자 카드 정보를 `Card` 1:1 엔티티로 분리했습니다.
- 사용자 소개서 정보를 `Introduction` 1:1 엔티티로 분리했습니다.
- 프로필/소개서 완료 상태를 플래그 대신 연관 엔티티 존재 여부로 판단하도록 정리했습니다.

## 주요 변경
- `Card` 엔티티 및 레포지토리 추가
- `Introduction` 엔티티 및 레포지토리 추가
- `User`에서 카드/소개서 관련 필드 제거
- `registerProfile` 메서드 제거 후 서비스에서 직접 값 반영
- 로그인 응답, 내 정보 응답 상태값을 연관 엔티티 기준으로 계산하도록 수정