### PR TITLE
feat: 소개팅 조회 및 소개 링크 생성 API 추가

### DIFF
--- a/src/main/java/com/domisa/domisa_backend/dating/controller/DatingController.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/controller/DatingController.java
@@ -1,8 +1,8 @@
 package com.domisa.domisa_backend.dating.controller;
 
 import com.domisa.domisa_backend.auth.annotation.AuthUser;
+import com.domisa.domisa_backend.dating.dto.DatingProfileListResponse;
 import com.domisa.domisa_backend.dating.dto.DatingProfileResponse;
-import com.domisa.domisa_backend.dating.dto.DatingProfilesResponse;
 import com.domisa.domisa_backend.dating.dto.DatingRefreshTimeResponse;
 import com.domisa.domisa_backend.dating.service.DatingService;
 import com.domisa.domisa_backend.user.entity.User;
@@ -21,7 +21,7 @@ public class DatingController {
 	private final DatingService datingService;
 
 	@GetMapping("/profiles")
-	public ResponseEntity<DatingProfilesResponse> getDatingProfiles(@AuthUser User authUser) {
+	public ResponseEntity<DatingProfileListResponse> getDatingProfiles(@AuthUser User authUser) {
 		return ResponseEntity.ok(datingService.getDatingProfiles(authUser));
 	}
 

--- a/src/main/java/com/domisa/domisa_backend/dating/controller/DatingController.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/controller/DatingController.java
@@ -1,6 +1,8 @@
 package com.domisa.domisa_backend.dating.controller;
 
 import com.domisa.domisa_backend.auth.annotation.AuthUser;
+import com.domisa.domisa_backend.dating.dto.DatingIntroductionLinkCreateRequest;
+import com.domisa.domisa_backend.dating.dto.DatingIntroductionLinkCreateResponse;
 import com.domisa.domisa_backend.dating.dto.DatingProfileListResponse;
 import com.domisa.domisa_backend.dating.dto.DatingProfileResponse;
 import com.domisa.domisa_backend.dating.dto.DatingRefreshTimeResponse;
@@ -10,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,5 +40,13 @@ public class DatingController {
 	@GetMapping("/refresh-time")
 	public ResponseEntity<DatingRefreshTimeResponse> getRefreshTime(@AuthUser User authUser) {
 		return ResponseEntity.ok(datingService.getDatingRefreshTime(authUser));
+	}
+
+	@PostMapping("/introduction-links")
+	public ResponseEntity<DatingIntroductionLinkCreateResponse> createIntroductionLink(
+		@AuthUser User authUser,
+		@RequestBody DatingIntroductionLinkCreateRequest request
+	) {
+		return ResponseEntity.ok(datingService.createIntroductionLink(authUser, request));
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/dating/controller/DatingController.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/controller/DatingController.java
@@ -2,6 +2,7 @@ package com.domisa.domisa_backend.dating.controller;
 
 import com.domisa.domisa_backend.auth.annotation.AuthUser;
 import com.domisa.domisa_backend.dating.dto.DatingProfileResponse;
+import com.domisa.domisa_backend.dating.dto.DatingProfilesResponse;
 import com.domisa.domisa_backend.dating.dto.DatingRefreshTimeResponse;
 import com.domisa.domisa_backend.dating.service.DatingService;
 import com.domisa.domisa_backend.user.entity.User;
@@ -18,6 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class DatingController {
 
 	private final DatingService datingService;
+
+	@GetMapping("/profiles")
+	public ResponseEntity<DatingProfilesResponse> getDatingProfiles(@AuthUser User authUser) {
+		return ResponseEntity.ok(datingService.getDatingProfiles(authUser));
+	}
 
 	@GetMapping("/profiles/{userId}")
 	public ResponseEntity<DatingProfileResponse> getDatingProfile(

--- a/src/main/java/com/domisa/domisa_backend/dating/controller/DatingController.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/controller/DatingController.java
@@ -1,10 +1,10 @@
-package com.domisa.domisa_backend.user.controller;
+package com.domisa.domisa_backend.dating.controller;
 
 import com.domisa.domisa_backend.auth.annotation.AuthUser;
-import com.domisa.domisa_backend.user.dto.DatingProfileResponse;
-import com.domisa.domisa_backend.user.dto.DatingRefreshTimeResponse;
+import com.domisa.domisa_backend.dating.dto.DatingProfileResponse;
+import com.domisa.domisa_backend.dating.dto.DatingRefreshTimeResponse;
+import com.domisa.domisa_backend.dating.service.DatingService;
 import com.domisa.domisa_backend.user.entity.User;
-import com.domisa.domisa_backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,18 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DatingController {
 
-	private final UserService userService;
+	private final DatingService datingService;
 
 	@GetMapping("/profiles/{userId}")
 	public ResponseEntity<DatingProfileResponse> getDatingProfile(
 		@AuthUser User authUser,
 		@PathVariable Long userId
 	) {
-		return ResponseEntity.ok(userService.getDatingProfile(authUser, userId));
+		return ResponseEntity.ok(datingService.getDatingProfile(authUser, userId));
 	}
 
 	@GetMapping("/refresh-time")
 	public ResponseEntity<DatingRefreshTimeResponse> getRefreshTime(@AuthUser User authUser) {
-		return ResponseEntity.ok(userService.getDatingRefreshTime(authUser));
+		return ResponseEntity.ok(datingService.getDatingRefreshTime(authUser));
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/dating/dto/DatingIntroductionLinkCreateRequest.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/dto/DatingIntroductionLinkCreateRequest.java
@@ -1,0 +1,8 @@
+package com.domisa.domisa_backend.dating.dto;
+
+public record DatingIntroductionLinkCreateRequest(
+	String q1,
+	String q2,
+	String q3
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/dating/dto/DatingIntroductionLinkCreateResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/dto/DatingIntroductionLinkCreateResponse.java
@@ -1,0 +1,6 @@
+package com.domisa.domisa_backend.dating.dto;
+
+public record DatingIntroductionLinkCreateResponse(
+	String linkCode
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/dating/dto/DatingProfileListResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/dto/DatingProfileListResponse.java
@@ -2,11 +2,11 @@ package com.domisa.domisa_backend.dating.dto;
 
 import java.util.List;
 
-public record DatingProfilesResponse(
+public record DatingProfileListResponse(
 	int profileNum,
-	List<DatingListProfile> profiles
+	List<ProfileSummary> profiles
 ) {
-	public record DatingListProfile(
+	public record ProfileSummary(
 		Long userId,
 		String profile
 	) {

--- a/src/main/java/com/domisa/domisa_backend/dating/dto/DatingProfileResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/dto/DatingProfileResponse.java
@@ -1,0 +1,23 @@
+package com.domisa.domisa_backend.dating.dto;
+
+import com.domisa.domisa_backend.user.dto.ContactDTO;
+import com.domisa.domisa_backend.user.type.AnimalProfile;
+import com.domisa.domisa_backend.user.type.Mbti;
+
+public record DatingProfileResponse(
+	Long userId,
+	String nickName,
+	Integer age,
+	AnimalProfile animalProfile,
+	String profile,
+	String q1,
+	String q2,
+	String q3,
+	String datingStyle,
+	String idealType,
+	Mbti mbti,
+	ContactDTO contact,
+	boolean isBlurred,
+	boolean hasSentLike
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/dating/dto/DatingProfilesResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/dto/DatingProfilesResponse.java
@@ -1,0 +1,14 @@
+package com.domisa.domisa_backend.dating.dto;
+
+import java.util.List;
+
+public record DatingProfilesResponse(
+	int profileNum,
+	List<DatingListProfile> profiles
+) {
+	public record DatingListProfile(
+		Long userId,
+		String profile
+	) {
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/dating/dto/DatingRefreshTimeResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/dto/DatingRefreshTimeResponse.java
@@ -1,0 +1,9 @@
+package com.domisa.domisa_backend.dating.dto;
+
+import java.time.LocalDateTime;
+
+public record DatingRefreshTimeResponse(
+	LocalDateTime refreshAvailableAt,
+	boolean canRefresh
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/dating/service/DatingService.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/service/DatingService.java
@@ -1,7 +1,7 @@
 package com.domisa.domisa_backend.dating.service;
 
 import com.domisa.domisa_backend.dating.dto.DatingProfileResponse;
-import com.domisa.domisa_backend.dating.dto.DatingProfilesResponse;
+import com.domisa.domisa_backend.dating.dto.DatingProfileListResponse;
 import com.domisa.domisa_backend.dating.dto.DatingRefreshTimeResponse;
 import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
 import com.domisa.domisa_backend.global.exception.GlobalException;
@@ -25,26 +25,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class DatingService {
 
 	private static final Duration REFRESH_INTERVAL = Duration.ofHours(2);
+	private static final int MAX_DATING_PROFILE_COUNT = 8;
 
 	private final UserRepository userRepository;
 	private final S3ObjectUrlService s3ObjectUrlService;
 
 	@Transactional(readOnly = true)
-	public DatingProfilesResponse getDatingProfiles(User authUser) {
+	public DatingProfileListResponse getDatingProfiles(User authUser) {
 		User requester = getRequiredUser(authUser);
 
 		List<Long> nowShowIds = requester.getNowShows() == null
 			? Collections.emptyList()
-			: requester.getNowShows();
+			: requester.getNowShows().stream().limit(MAX_DATING_PROFILE_COUNT).toList();
 		Set<Long> unblurIds = requester.getMyBlurs() == null
 			? Collections.emptySet()
 			: new HashSet<>(requester.getMyBlurs());
 		LinkedHashMap<Long, User> usersById = getUsersById(nowShowIds);
 
-		List<DatingProfilesResponse.DatingListProfile> profiles = nowShowIds.stream()
+		List<DatingProfileListResponse.ProfileSummary> profiles = nowShowIds.stream()
 			.map(usersById::get)
 			.filter(targetUser -> targetUser != null)
-			.map(targetUser -> new DatingProfilesResponse.DatingListProfile(
+			.map(targetUser -> new DatingProfileListResponse.ProfileSummary(
 				targetUser.getId(),
 				unblurIds.contains(targetUser.getId())
 					? s3ObjectUrlService.getThumbnailUrl(targetUser.getProfileImage())
@@ -52,7 +53,7 @@ public class DatingService {
 			))
 			.toList();
 
-		return new DatingProfilesResponse(profiles.size(), profiles);
+		return new DatingProfileListResponse(profiles.size(), profiles);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/domisa/domisa_backend/dating/service/DatingService.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/service/DatingService.java
@@ -1,0 +1,78 @@
+package com.domisa.domisa_backend.dating.service;
+
+import com.domisa.domisa_backend.dating.dto.DatingProfileResponse;
+import com.domisa.domisa_backend.dating.dto.DatingRefreshTimeResponse;
+import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
+import com.domisa.domisa_backend.global.exception.GlobalException;
+import com.domisa.domisa_backend.global.s3.service.S3ObjectUrlService;
+import com.domisa.domisa_backend.user.dto.ContactDTO;
+import com.domisa.domisa_backend.user.entity.User;
+import com.domisa.domisa_backend.user.repository.UserRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DatingService {
+
+	private static final Duration REFRESH_INTERVAL = Duration.ofHours(2);
+
+	private final UserRepository userRepository;
+	private final S3ObjectUrlService s3ObjectUrlService;
+
+	@Transactional(readOnly = true)
+	public DatingProfileResponse getDatingProfile(User authUser, Long userId) {
+		User requester = getRequiredUser(authUser);
+		User targetUser = userRepository.findDatingProfileById(userId)
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
+
+		boolean isBlurred = requester.getMyBlurs() == null || !requester.getMyBlurs().contains(userId);
+		boolean hasSentLike = requester.getMyTypes() != null && requester.getMyTypes().contains(userId);
+
+		String profileUrl = isBlurred
+			? s3ObjectUrlService.getOriginBlurUrl(targetUser.getProfileImage())
+			: s3ObjectUrlService.getProfileImageUrl(targetUser.getProfileImage());
+		ContactDTO contact = isBlurred
+			? null
+			: new ContactDTO(targetUser.getContactType(), targetUser.getContact());
+
+		return new DatingProfileResponse(
+			targetUser.getId(),
+			targetUser.getNickname(),
+			targetUser.getAge(),
+			targetUser.getAnimalProfile(),
+			profileUrl,
+			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ1(),
+			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ2(),
+			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ3(),
+			targetUser.getCard() == null ? null : targetUser.getCard().getDatingStyle(),
+			targetUser.getCard() == null ? null : targetUser.getCard().getIdealType(),
+			targetUser.getCard() == null ? null : targetUser.getCard().getMbti(),
+			contact,
+			isBlurred,
+			hasSentLike
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public DatingRefreshTimeResponse getDatingRefreshTime(User authUser) {
+		User user = getRequiredUser(authUser);
+		LocalDateTime refreshAvailableAt = user.getRefreshAt() == null
+			? null
+			: user.getRefreshAt().plus(REFRESH_INTERVAL);
+		boolean canRefresh = refreshAvailableAt == null || !LocalDateTime.now().isBefore(refreshAvailableAt);
+		return new DatingRefreshTimeResponse(refreshAvailableAt, canRefresh);
+	}
+
+	private User getRequiredUser(User authUser) {
+		// 요청 유저는 프로필 이미지까지 같이 읽고 myBlurs, myTypes, nowShows를 기준으로 응답을 만든다.
+		if (authUser == null || authUser.getId() == null) {
+			throw new GlobalException(GlobalErrorCode.USER_NOT_FOUND);
+		}
+		return userRepository.findWithProfileImageById(authUser.getId())
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/dating/service/DatingService.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/service/DatingService.java
@@ -1,11 +1,15 @@
 package com.domisa.domisa_backend.dating.service;
 
+import com.domisa.domisa_backend.dating.dto.DatingIntroductionLinkCreateRequest;
+import com.domisa.domisa_backend.dating.dto.DatingIntroductionLinkCreateResponse;
 import com.domisa.domisa_backend.dating.dto.DatingProfileResponse;
 import com.domisa.domisa_backend.dating.dto.DatingProfileListResponse;
 import com.domisa.domisa_backend.dating.dto.DatingRefreshTimeResponse;
 import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
 import com.domisa.domisa_backend.global.exception.GlobalException;
 import com.domisa.domisa_backend.global.s3.service.S3ObjectUrlService;
+import com.domisa.domisa_backend.introduction.entity.Introduction;
+import com.domisa.domisa_backend.introduction.repository.IntroductionRepository;
 import com.domisa.domisa_backend.user.dto.ContactDTO;
 import com.domisa.domisa_backend.user.entity.User;
 import com.domisa.domisa_backend.user.repository.UserRepository;
@@ -16,6 +20,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +33,7 @@ public class DatingService {
 	private static final int MAX_DATING_PROFILE_COUNT = 8;
 
 	private final UserRepository userRepository;
+	private final IntroductionRepository introductionRepository;
 	private final S3ObjectUrlService s3ObjectUrlService;
 
 	@Transactional(readOnly = true)
@@ -100,6 +106,25 @@ public class DatingService {
 		return new DatingRefreshTimeResponse(refreshAvailableAt, canRefresh);
 	}
 
+	@Transactional
+	public DatingIntroductionLinkCreateResponse createIntroductionLink(
+		User authUser,
+		DatingIntroductionLinkCreateRequest request
+	) {
+		User introducer = getRequiredUser(authUser);
+		String linkCode = generateUniqueLinkCode();
+
+		introductionRepository.save(Introduction.create(
+			request.q1(),
+			request.q2(),
+			request.q3(),
+			introducer,
+			linkCode
+		));
+
+		return new DatingIntroductionLinkCreateResponse(linkCode);
+	}
+
 	private LinkedHashMap<Long, User> getUsersById(List<Long> userIds) {
 		// 소개팅 목록은 한 번에 조회해서 프로필 이미지 N+1을 줄인다.
 		LinkedHashMap<Long, User> usersById = new LinkedHashMap<>();
@@ -118,5 +143,13 @@ public class DatingService {
 		}
 		return userRepository.findWithProfileImageById(authUser.getId())
 			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
+	}
+
+	private String generateUniqueLinkCode() {
+		String linkCode;
+		do {
+			linkCode = UUID.randomUUID().toString().replace("-", "").substring(0, 8).toUpperCase();
+		} while (introductionRepository.findByLinkCode(linkCode).isPresent());
+		return linkCode;
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/dating/service/DatingService.java
+++ b/src/main/java/com/domisa/domisa_backend/dating/service/DatingService.java
@@ -1,6 +1,7 @@
 package com.domisa.domisa_backend.dating.service;
 
 import com.domisa.domisa_backend.dating.dto.DatingProfileResponse;
+import com.domisa.domisa_backend.dating.dto.DatingProfilesResponse;
 import com.domisa.domisa_backend.dating.dto.DatingRefreshTimeResponse;
 import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
 import com.domisa.domisa_backend.global.exception.GlobalException;
@@ -10,6 +11,11 @@ import com.domisa.domisa_backend.user.entity.User;
 import com.domisa.domisa_backend.user.repository.UserRepository;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +28,32 @@ public class DatingService {
 
 	private final UserRepository userRepository;
 	private final S3ObjectUrlService s3ObjectUrlService;
+
+	@Transactional(readOnly = true)
+	public DatingProfilesResponse getDatingProfiles(User authUser) {
+		User requester = getRequiredUser(authUser);
+
+		List<Long> nowShowIds = requester.getNowShows() == null
+			? Collections.emptyList()
+			: requester.getNowShows();
+		Set<Long> unblurIds = requester.getMyBlurs() == null
+			? Collections.emptySet()
+			: new HashSet<>(requester.getMyBlurs());
+		LinkedHashMap<Long, User> usersById = getUsersById(nowShowIds);
+
+		List<DatingProfilesResponse.DatingListProfile> profiles = nowShowIds.stream()
+			.map(usersById::get)
+			.filter(targetUser -> targetUser != null)
+			.map(targetUser -> new DatingProfilesResponse.DatingListProfile(
+				targetUser.getId(),
+				unblurIds.contains(targetUser.getId())
+					? s3ObjectUrlService.getThumbnailUrl(targetUser.getProfileImage())
+					: s3ObjectUrlService.getThumbnailBlurUrl(targetUser.getProfileImage())
+			))
+			.toList();
+
+		return new DatingProfilesResponse(profiles.size(), profiles);
+	}
 
 	@Transactional(readOnly = true)
 	public DatingProfileResponse getDatingProfile(User authUser, Long userId) {
@@ -65,6 +97,17 @@ public class DatingService {
 			: user.getRefreshAt().plus(REFRESH_INTERVAL);
 		boolean canRefresh = refreshAvailableAt == null || !LocalDateTime.now().isBefore(refreshAvailableAt);
 		return new DatingRefreshTimeResponse(refreshAvailableAt, canRefresh);
+	}
+
+	private LinkedHashMap<Long, User> getUsersById(List<Long> userIds) {
+		// 소개팅 목록은 한 번에 조회해서 프로필 이미지 N+1을 줄인다.
+		LinkedHashMap<Long, User> usersById = new LinkedHashMap<>();
+		if (userIds.isEmpty()) {
+			return usersById;
+		}
+		userRepository.findAllByIdIn(userIds)
+			.forEach(user -> usersById.put(user.getId(), user));
+		return usersById;
 	}
 
 	private User getRequiredUser(User authUser) {

--- a/src/main/java/com/domisa/domisa_backend/global/s3/service/S3ObjectUrlService.java
+++ b/src/main/java/com/domisa/domisa_backend/global/s3/service/S3ObjectUrlService.java
@@ -56,6 +56,17 @@ public class S3ObjectUrlService {
 		return null;
 	}
 
+	public String getOriginBlurUrl(ProfileImage profileImage) {
+		// 블러 프로필 상세는 READY 상태의 origin blur만 사용한다.
+		if (profileImage == null) {
+			return null;
+		}
+		if (isReady(profileImage) && hasText(profileImage.getProfileOriginBlurKey())) {
+			return buildStoredObjectUrl(profileImage.getProfileOriginBlurKey());
+		}
+		return null;
+	}
+
 	public String getObjectUrl(String objectKey) {
 		// 임의 key 조회는 존재 여부를 확인한 뒤 URL을 만든다.
 		String normalizedObjectKey = normalizeObjectKey(objectKey);

--- a/src/main/java/com/domisa/domisa_backend/introduction/dto/IntroductionResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/introduction/dto/IntroductionResponse.java
@@ -1,10 +1,8 @@
 package com.domisa.domisa_backend.introduction.dto;
 
 import com.domisa.domisa_backend.introduction.entity.Introduction;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record IntroductionResponse(
-	@JsonProperty("introduction_id")
 	Long introductionId,
 	String q1,
 	String q2,

--- a/src/main/java/com/domisa/domisa_backend/introduction/entity/Introduction.java
+++ b/src/main/java/com/domisa/domisa_backend/introduction/entity/Introduction.java
@@ -47,5 +47,16 @@ public class Introduction {
 	public void assignParticipant(User participant) {
 		this.participant = participant;
 		participant.setIntroduction(this);
+		participant.setHasIntroduction(true);
+	}
+
+	public void clearParticipant() {
+		if (this.participant == null) {
+			return;
+		}
+		User currentParticipant = this.participant;
+		this.participant = null;
+		currentParticipant.setIntroduction(null);
+		currentParticipant.setHasIntroduction(false);
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/introduction/entity/Introduction.java
+++ b/src/main/java/com/domisa/domisa_backend/introduction/entity/Introduction.java
@@ -44,6 +44,18 @@ public class Introduction {
 	@Column(name = "link_code")
 	private String linkCode;
 
+	private Introduction(String q1, String q2, String q3, User introducer, String linkCode) {
+		this.q1 = q1;
+		this.q2 = q2;
+		this.q3 = q3;
+		this.introducer = introducer;
+		this.linkCode = linkCode;
+	}
+
+	public static Introduction create(String q1, String q2, String q3, User introducer, String linkCode) {
+		return new Introduction(q1, q2, q3, introducer, linkCode);
+	}
+
 	public void assignParticipant(User participant) {
 		this.participant = participant;
 		participant.setIntroduction(this);

--- a/src/main/java/com/domisa/domisa_backend/introduction/service/IntroductionService.java
+++ b/src/main/java/com/domisa/domisa_backend/introduction/service/IntroductionService.java
@@ -6,6 +6,7 @@ import com.domisa.domisa_backend.introduction.dto.IntroductionResponse;
 import com.domisa.domisa_backend.introduction.entity.Introduction;
 import com.domisa.domisa_backend.introduction.repository.IntroductionRepository;
 import com.domisa.domisa_backend.user.entity.User;
+import com.domisa.domisa_backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class IntroductionService {
 
 	private final IntroductionRepository introductionRepository;
+	private final UserRepository userRepository;
 
 	@Transactional(readOnly = true)
 	public IntroductionResponse getIntroductionByLinkCode(String linkCode) {
@@ -25,22 +27,27 @@ public class IntroductionService {
 
 	@Transactional
 	public void acceptIntroduction(Long introductionId, User user) {
+		User participant = userRepository.findById(user.getId())
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
+
 		Introduction introduction = introductionRepository.findById(introductionId)
 			.orElseThrow(() -> new GlobalException(GlobalErrorCode.INTRODUCTION_NOT_FOUND));
 
 		// 소개서의 등록된 사람이 있으면
 		if (introduction.getParticipant() != null) {
-			if (introduction.getParticipant().getId().equals(user.getId())) {
+			if (introduction.getParticipant().getId().equals(participant.getId())) {
 				return;
 			}
 			throw new GlobalException(GlobalErrorCode.INTRODUCTION_ALREADY_ACCEPTED);
 		}
 
-		// 유저가 이미 소개서가 있으면 문제
-		if (user.hasIntroduction()) {
-			throw new GlobalException(GlobalErrorCode.USER_ALREADY_HAS_INTRODUCTION);
+		// 기존 소개서가 있으면 먼저 연결을 해제하고 새 소개서로 갈아탄다.
+		Introduction currentIntroduction = participant.getIntroduction();
+		if (currentIntroduction != null && !currentIntroduction.getId().equals(introduction.getId())) {
+			currentIntroduction.clearParticipant();
 		}
+
 		// 유저에도 등록, 소개서에서도 유저 등록
-		introduction.assignParticipant(user);
+		introduction.assignParticipant(participant);
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/profile/dto/MyIntroductionResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/profile/dto/MyIntroductionResponse.java
@@ -1,0 +1,18 @@
+package com.domisa.domisa_backend.profile.dto;
+
+import com.domisa.domisa_backend.introduction.entity.Introduction;
+
+public record MyIntroductionResponse(
+	String q1,
+	String q2,
+	String q3
+) {
+
+	public static MyIntroductionResponse from(Introduction introduction) {
+		return new MyIntroductionResponse(
+			introduction.getQ1(),
+			introduction.getQ2(),
+			introduction.getQ3()
+		);
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/profile/dto/ProfileRegisterResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/profile/dto/ProfileRegisterResponse.java
@@ -2,7 +2,8 @@ package com.domisa.domisa_backend.profile.dto;
 
 public record ProfileRegisterResponse(
         Long userId,
-        StatusDto status
+        StatusDto status,
+        long totalUserCount
 ) {
     public record StatusDto(
             boolean isRegistered,       // 회원가입 완료하면 true

--- a/src/main/java/com/domisa/domisa_backend/profile/service/ProfileService.java
+++ b/src/main/java/com/domisa/domisa_backend/profile/service/ProfileService.java
@@ -49,6 +49,7 @@ public class ProfileService {
 		user.setContact(request.contact().content());      // ContactDTO에서 content 꺼내기
 		user.setInviteCode(request.inviteCode());
 		user.setIsRegistered(true);
+		long totalUserCount = Math.max(0, userRepository.count() - 1);
 
 		return new ProfileRegisterResponse(
 				user.getId(),
@@ -56,7 +57,8 @@ public class ProfileService {
 						user.getIsRegistered(),
 						user.hasIntroduction(),
 						user.hasCard()
-				)
+				),
+				totalUserCount
 		);
 	}
 

--- a/src/main/java/com/domisa/domisa_backend/user/controller/DatingController.java
+++ b/src/main/java/com/domisa/domisa_backend/user/controller/DatingController.java
@@ -1,0 +1,24 @@
+package com.domisa.domisa_backend.user.controller;
+
+import com.domisa.domisa_backend.auth.annotation.AuthUser;
+import com.domisa.domisa_backend.user.dto.DatingRefreshTimeResponse;
+import com.domisa.domisa_backend.user.entity.User;
+import com.domisa.domisa_backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/datings")
+@RequiredArgsConstructor
+public class DatingController {
+
+	private final UserService userService;
+
+	@GetMapping("/refresh-time")
+	public ResponseEntity<DatingRefreshTimeResponse> getRefreshTime(@AuthUser User authUser) {
+		return ResponseEntity.ok(userService.getDatingRefreshTime(authUser));
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/user/controller/DatingController.java
+++ b/src/main/java/com/domisa/domisa_backend/user/controller/DatingController.java
@@ -1,12 +1,14 @@
 package com.domisa.domisa_backend.user.controller;
 
 import com.domisa.domisa_backend.auth.annotation.AuthUser;
+import com.domisa.domisa_backend.user.dto.DatingProfileResponse;
 import com.domisa.domisa_backend.user.dto.DatingRefreshTimeResponse;
 import com.domisa.domisa_backend.user.entity.User;
 import com.domisa.domisa_backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class DatingController {
 
 	private final UserService userService;
+
+	@GetMapping("/profiles/{userId}")
+	public ResponseEntity<DatingProfileResponse> getDatingProfile(
+		@AuthUser User authUser,
+		@PathVariable Long userId
+	) {
+		return ResponseEntity.ok(userService.getDatingProfile(authUser, userId));
+	}
 
 	@GetMapping("/refresh-time")
 	public ResponseEntity<DatingRefreshTimeResponse> getRefreshTime(@AuthUser User authUser) {

--- a/src/main/java/com/domisa/domisa_backend/user/controller/UserController.java
+++ b/src/main/java/com/domisa/domisa_backend/user/controller/UserController.java
@@ -1,11 +1,13 @@
 package com.domisa.domisa_backend.user.controller;
 
 import com.domisa.domisa_backend.auth.annotation.AuthUser;
+import com.domisa.domisa_backend.profile.dto.MyIntroductionResponse;
 import com.domisa.domisa_backend.profile.dto.ProfileRegisterRequest;
 import com.domisa.domisa_backend.profile.dto.ProfileRegisterResponse;
 import com.domisa.domisa_backend.profile.dto.ProfileUpdateRequest;
 import com.domisa.domisa_backend.profile.dto.ProfileUpdateResponse;
 import com.domisa.domisa_backend.profile.service.ProfileService;
+import com.domisa.domisa_backend.user.dto.UserCookiesResponse;
 import com.domisa.domisa_backend.user.dto.UserLikesReceivedResponse;
 import com.domisa.domisa_backend.user.dto.UserLikesSentResponse;
 import com.domisa.domisa_backend.user.dto.UserMeResponse;
@@ -38,18 +40,28 @@ public class UserController {
 	}
 
 	// 회원가입
-	@PostMapping("/register")
+	@PostMapping({"/register", "/profiles"})
 	public ResponseEntity<ProfileRegisterResponse> registerProfile(
-			@AuthUser Long userId,
+			@AuthUser User authUser,
 			@RequestBody ProfileRegisterRequest request
 	) {
-		return ResponseEntity.ok(profileService.registerProfile(userId, request));
+		return ResponseEntity.ok(profileService.registerProfile(authUser.getId(), request));
 	}
 
 	// 내 정보 조회(마이페이지용)
 	@GetMapping("/me")
 	public ResponseEntity<UserMeResponse> getMe(@AuthUser User authUser) {
 		return ResponseEntity.ok(userService.getMe(authUser));
+	}
+
+	@GetMapping("/introduction")
+	public ResponseEntity<MyIntroductionResponse> getMyIntroduction(@AuthUser User authUser) {
+		return ResponseEntity.ok(userService.getMyIntroduction(authUser));
+	}
+
+	@GetMapping("/cookies")
+	public ResponseEntity<UserCookiesResponse> getMyCookies(@AuthUser User authUser) {
+		return ResponseEntity.ok(userService.getMyCookies(authUser));
 	}
 
 	@GetMapping("/likes/received")
@@ -65,9 +77,9 @@ public class UserController {
 	// 나의 프로필 수정
 	@PutMapping("/me")
 	public ResponseEntity<ProfileUpdateResponse> updateResponse(
-			@AuthUser Long userId,
+			@AuthUser User authUser,
 			@RequestBody ProfileUpdateRequest request
 	) {
-		return ResponseEntity.ok(profileService.updateProfile(userId, request));
+		return ResponseEntity.ok(profileService.updateProfile(authUser.getId(), request));
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/user/dto/DatingProfileResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/user/dto/DatingProfileResponse.java
@@ -1,0 +1,22 @@
+package com.domisa.domisa_backend.user.dto;
+
+import com.domisa.domisa_backend.user.type.AnimalProfile;
+import com.domisa.domisa_backend.user.type.Mbti;
+
+public record DatingProfileResponse(
+	Long userId,
+	String nickName,
+	Integer age,
+	AnimalProfile animalProfile,
+	String profile,
+	String q1,
+	String q2,
+	String q3,
+	String datingStyle,
+	String idealType,
+	Mbti mbti,
+	ContactDTO contact,
+	boolean isBlurred,
+	boolean hasSentLike
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/user/dto/DatingRefreshTimeResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/user/dto/DatingRefreshTimeResponse.java
@@ -1,0 +1,9 @@
+package com.domisa.domisa_backend.user.dto;
+
+import java.time.LocalDateTime;
+
+public record DatingRefreshTimeResponse(
+	LocalDateTime refreshAvailableAt,
+	boolean canRefresh
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/user/dto/UserCookiesResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/user/dto/UserCookiesResponse.java
@@ -1,0 +1,6 @@
+package com.domisa.domisa_backend.user.dto;
+
+public record UserCookiesResponse(
+	long cookieCount
+) {
+}

--- a/src/main/java/com/domisa/domisa_backend/user/entity/User.java
+++ b/src/main/java/com/domisa/domisa_backend/user/entity/User.java
@@ -96,9 +96,8 @@ public class User {
 	@Column(name = "target_user_id")
 	private List<Long> nowShows;
 
-	@Column(name = "shows_refresh_at")
-	private LocalDateTime showsRefreshAt;
-
+	@Column(name = "refresh_at")
+	private LocalDateTime refreshAt;
 
 	@Column(name = "kakao_id", nullable = false, unique = true)
 	private Long kakaoId;

--- a/src/main/java/com/domisa/domisa_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/domisa/domisa_backend/user/repository/UserRepository.java
@@ -14,6 +14,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@EntityGraph(attributePaths = "profileImage")
 	Optional<User> findWithProfileImageById(Long id);
 
+	@EntityGraph(attributePaths = {"profileImage", "card", "introduction"})
+	Optional<User> findDatingProfileById(Long id);
+
 	@EntityGraph(attributePaths = "profileImage")
 	List<User> findAllByIdIn(Collection<Long> ids);
 

--- a/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
+++ b/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
@@ -4,18 +4,13 @@ import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
 import com.domisa.domisa_backend.global.exception.GlobalException;
 import com.domisa.domisa_backend.global.s3.service.S3ObjectUrlService;
 import com.domisa.domisa_backend.profile.dto.MyIntroductionResponse;
-import com.domisa.domisa_backend.user.dto.DatingProfileResponse;
-import com.domisa.domisa_backend.profileimage.entity.ProfileImage;
 import com.domisa.domisa_backend.user.dto.ContactDTO;
-import com.domisa.domisa_backend.user.dto.DatingRefreshTimeResponse;
 import com.domisa.domisa_backend.user.dto.UserCookiesResponse;
 import com.domisa.domisa_backend.user.dto.UserMeResponse;
 import com.domisa.domisa_backend.user.dto.UserLikesReceivedResponse;
 import com.domisa.domisa_backend.user.dto.UserLikesSentResponse;
 import com.domisa.domisa_backend.user.entity.User;
 import com.domisa.domisa_backend.user.repository.UserRepository;
-import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -27,8 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserService {
 
-	private static final Duration REFRESH_INTERVAL = Duration.ofHours(2);
-
 	private final UserRepository userRepository;
 	private final S3ObjectUrlService s3ObjectUrlService;
 
@@ -37,7 +30,6 @@ public class UserService {
 	public UserMeResponse getMe(User authUser) {
 		// 내 정보 조회는 프로필 이미지까지 함께 읽어서 응답한다.
 		User user = getRequiredUser(authUser);
-		ProfileImage profileImage = user.getProfileImage();
 
 		return new UserMeResponse(
 			user.getId(),
@@ -63,50 +55,6 @@ public class UserService {
 	public UserCookiesResponse getMyCookies(User authUser) {
 		User user = getRequiredUser(authUser);
 		return new UserCookiesResponse(user.getCookies() == null ? 0L : user.getCookies());
-	}
-
-	@Transactional(readOnly = true)
-	public DatingRefreshTimeResponse getDatingRefreshTime(User authUser) {
-		User user = getRequiredUser(authUser);
-		LocalDateTime refreshAvailableAt = user.getRefreshAt() == null
-			? null
-			: user.getRefreshAt().plus(REFRESH_INTERVAL);
-		boolean canRefresh = refreshAvailableAt == null || !LocalDateTime.now().isBefore(refreshAvailableAt);
-		return new DatingRefreshTimeResponse(refreshAvailableAt, canRefresh);
-	}
-
-	@Transactional(readOnly = true)
-	public DatingProfileResponse getDatingProfile(User authUser, Long userId) {
-		User requester = getRequiredUser(authUser);
-		User targetUser = userRepository.findDatingProfileById(userId)
-			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
-
-		boolean isBlurred = requester.getMyBlurs() == null || !requester.getMyBlurs().contains(userId);
-		boolean hasSentLike = requester.getMyTypes() != null && requester.getMyTypes().contains(userId);
-
-		String profileUrl = isBlurred
-			? s3ObjectUrlService.getOriginBlurUrl(targetUser.getProfileImage())
-			: s3ObjectUrlService.getProfileImageUrl(targetUser.getProfileImage());
-		ContactDTO contact = isBlurred
-			? null
-			: new ContactDTO(targetUser.getContactType(), targetUser.getContact());
-
-		return new DatingProfileResponse(
-			targetUser.getId(),
-			targetUser.getNickname(),
-			targetUser.getAge(),
-			targetUser.getAnimalProfile(),
-			profileUrl,
-			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ1(),
-			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ2(),
-			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ3(),
-			targetUser.getCard() == null ? null : targetUser.getCard().getDatingStyle(),
-			targetUser.getCard() == null ? null : targetUser.getCard().getIdealType(),
-			targetUser.getCard() == null ? null : targetUser.getCard().getMbti(),
-			contact,
-			isBlurred,
-			hasSentLike
-		);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
+++ b/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
@@ -3,13 +3,18 @@ package com.domisa.domisa_backend.user.service;
 import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
 import com.domisa.domisa_backend.global.exception.GlobalException;
 import com.domisa.domisa_backend.global.s3.service.S3ObjectUrlService;
+import com.domisa.domisa_backend.profile.dto.MyIntroductionResponse;
 import com.domisa.domisa_backend.profileimage.entity.ProfileImage;
 import com.domisa.domisa_backend.user.dto.ContactDTO;
+import com.domisa.domisa_backend.user.dto.DatingRefreshTimeResponse;
+import com.domisa.domisa_backend.user.dto.UserCookiesResponse;
 import com.domisa.domisa_backend.user.dto.UserMeResponse;
 import com.domisa.domisa_backend.user.dto.UserLikesReceivedResponse;
 import com.domisa.domisa_backend.user.dto.UserLikesSentResponse;
 import com.domisa.domisa_backend.user.entity.User;
 import com.domisa.domisa_backend.user.repository.UserRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -20,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+	private static final Duration REFRESH_INTERVAL = Duration.ofHours(2);
 
 	private final UserRepository userRepository;
 	private final S3ObjectUrlService s3ObjectUrlService;
@@ -40,6 +47,31 @@ public class UserService {
 			new ContactDTO(user.getContactType(), user.getContact()),
 			user.getInviteCode()
 		);
+	}
+
+	@Transactional(readOnly = true)
+	public MyIntroductionResponse getMyIntroduction(User authUser) {
+		User user = getRequiredUser(authUser);
+		if (user.getIntroduction() == null) {
+			return null;
+		}
+		return MyIntroductionResponse.from(user.getIntroduction());
+	}
+
+	@Transactional(readOnly = true)
+	public UserCookiesResponse getMyCookies(User authUser) {
+		User user = getRequiredUser(authUser);
+		return new UserCookiesResponse(user.getCookies() == null ? 0L : user.getCookies());
+	}
+
+	@Transactional(readOnly = true)
+	public DatingRefreshTimeResponse getDatingRefreshTime(User authUser) {
+		User user = getRequiredUser(authUser);
+		LocalDateTime refreshAvailableAt = user.getRefreshAt() == null
+			? null
+			: user.getRefreshAt().plus(REFRESH_INTERVAL);
+		boolean canRefresh = refreshAvailableAt == null || !LocalDateTime.now().isBefore(refreshAvailableAt);
+		return new DatingRefreshTimeResponse(refreshAvailableAt, canRefresh);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
+++ b/src/main/java/com/domisa/domisa_backend/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
 import com.domisa.domisa_backend.global.exception.GlobalException;
 import com.domisa.domisa_backend.global.s3.service.S3ObjectUrlService;
 import com.domisa.domisa_backend.profile.dto.MyIntroductionResponse;
+import com.domisa.domisa_backend.user.dto.DatingProfileResponse;
 import com.domisa.domisa_backend.profileimage.entity.ProfileImage;
 import com.domisa.domisa_backend.user.dto.ContactDTO;
 import com.domisa.domisa_backend.user.dto.DatingRefreshTimeResponse;
@@ -72,6 +73,40 @@ public class UserService {
 			: user.getRefreshAt().plus(REFRESH_INTERVAL);
 		boolean canRefresh = refreshAvailableAt == null || !LocalDateTime.now().isBefore(refreshAvailableAt);
 		return new DatingRefreshTimeResponse(refreshAvailableAt, canRefresh);
+	}
+
+	@Transactional(readOnly = true)
+	public DatingProfileResponse getDatingProfile(User authUser, Long userId) {
+		User requester = getRequiredUser(authUser);
+		User targetUser = userRepository.findDatingProfileById(userId)
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
+
+		boolean isBlurred = requester.getMyBlurs() == null || !requester.getMyBlurs().contains(userId);
+		boolean hasSentLike = requester.getMyTypes() != null && requester.getMyTypes().contains(userId);
+
+		String profileUrl = isBlurred
+			? s3ObjectUrlService.getOriginBlurUrl(targetUser.getProfileImage())
+			: s3ObjectUrlService.getProfileImageUrl(targetUser.getProfileImage());
+		ContactDTO contact = isBlurred
+			? null
+			: new ContactDTO(targetUser.getContactType(), targetUser.getContact());
+
+		return new DatingProfileResponse(
+			targetUser.getId(),
+			targetUser.getNickname(),
+			targetUser.getAge(),
+			targetUser.getAnimalProfile(),
+			profileUrl,
+			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ1(),
+			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ2(),
+			targetUser.getIntroduction() == null ? null : targetUser.getIntroduction().getQ3(),
+			targetUser.getCard() == null ? null : targetUser.getCard().getDatingStyle(),
+			targetUser.getCard() == null ? null : targetUser.getCard().getIdealType(),
+			targetUser.getCard() == null ? null : targetUser.getCard().getMbti(),
+			contact,
+			isBlurred,
+			hasSentLike
+		);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
## 작업 내용

- 소개팅 도메인을 `dating` 패키지로 분리했습니다.
- `GET /api/datings/profiles/{userId}` 상세 조회 API를 추가했습니다.
- `GET /api/datings/profiles` 목록 조회 API를 추가했습니다.
  - `nowShows` 기준 최대 8명 조회
  - `myBlurs` 기준으로 일반 썸네일/블러 썸네일 분기
- `GET /api/datings/refresh-time`를 dating 도메인으로 이동했습니다.
- `POST /api/datings/introduction-links`를 추가했습니다.
  - 소개서 생성
  - 랜덤 `linkCode` 발급
  - `introducer` 연결