### PR TITLE
feat: 알림 조회/수정 API 구조 개편 및 활성 알림 조회 추가

### DIFF
--- a/src/main/java/com/domisa/domisa_backend/notification/controller/NotificationController.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.domisa.domisa_backend.notification.controller;
 
 import com.domisa.domisa_backend.notification.dto.NotificationListResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationSimpleListResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
 import com.domisa.domisa_backend.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,13 @@ public class NotificationController {
 	@GetMapping
 	public ResponseEntity<NotificationListResponse> getNotifications(@AuthenticationPrincipal Long userId) {
 		return ResponseEntity.ok(notificationService.getNotifications(userId));
+	}
+
+	@GetMapping("/active")
+	public ResponseEntity<NotificationSimpleListResponse> getActiveNotifications(
+		@AuthenticationPrincipal Long userId
+	) {
+		return ResponseEntity.ok(notificationService.getActiveNotifications(userId));
 	}
 
 	@GetMapping("/status")

--- a/src/main/java/com/domisa/domisa_backend/notification/controller/NotificationController.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/controller/NotificationController.java
@@ -1,16 +1,16 @@
 package com.domisa.domisa_backend.notification.controller;
 
 import com.domisa.domisa_backend.notification.dto.NotificationListResponse;
-import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationSimpleListResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationUpdateRequest;
 import com.domisa.domisa_backend.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,11 +38,12 @@ public class NotificationController {
 		return ResponseEntity.ok(notificationService.getNotificationStatus(userId));
 	}
 
-	@PostMapping("/{notificationId}")
-	public ResponseEntity<NotificationReadResponse> markAsRead(
+	@PostMapping
+	public ResponseEntity<Void> updateNotification(
 		@AuthenticationPrincipal Long userId,
-		@PathVariable Long notificationId
+		@RequestBody NotificationUpdateRequest request
 	) {
-		return ResponseEntity.ok(notificationService.markAsRead(userId, notificationId));
+		notificationService.updateNotification(userId, request);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationListResponse.java
@@ -1,6 +1,8 @@
 package com.domisa.domisa_backend.notification.dto;
 
 import com.domisa.domisa_backend.notification.type.NotificationType;
+import com.domisa.domisa_backend.user.type.AnimalProfile;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -9,10 +11,10 @@ public record NotificationListResponse(List<NotificationItem> notifications) {
 	public record NotificationItem(
 		Long notificationId,
 		String userId,
-		String targetUserId,
 		NotificationType type,
-		String title,
-		String content,
+		String targetUserId,
+		AnimalProfile animalProfile,
+		String personNickname,
 		boolean isRead,
 		LocalDateTime createdAt
 	) {

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationSimpleListResponse.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationSimpleListResponse.java
@@ -1,0 +1,14 @@
+package com.domisa.domisa_backend.notification.dto;
+
+import com.domisa.domisa_backend.notification.type.NotificationType;
+import java.util.List;
+
+public record NotificationSimpleListResponse(List<NotificationItem> notifications) {
+
+	public record NotificationItem(
+		Long notificationId,
+		String userId,
+		NotificationType type
+	) {
+	}
+}

--- a/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationUpdateRequest.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/dto/NotificationUpdateRequest.java
@@ -1,7 +1,8 @@
 package com.domisa.domisa_backend.notification.dto;
 
-public record NotificationReadResponse(
+public record NotificationUpdateRequest(
 	Long notificationId,
-	boolean isRead
+	boolean isRead,
+	boolean isClosed
 ) {
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -37,6 +37,9 @@ public class Notification {
 	@Column(name = "is_read", nullable = false)
 	private boolean isRead = false;
 
+	@Column(name = "is_canceled", nullable = false)
+	private boolean isCanceled = false;
+
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -66,7 +66,8 @@ public class Notification {
 		return new Notification(userId, targetUserId, type);
 	}
 
-	public void markAsRead() {
-		this.isRead = true;
+	public void updateStatus(boolean isRead, boolean isClosed) {
+		this.isRead = isRead;
+		this.isCanceled = isClosed;
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/entity/Notification.java
@@ -34,50 +34,36 @@ public class Notification {
 	@Column(name = "type", nullable = false, length = 20)
 	private NotificationType type;
 
-	@Column(name = "title", nullable = false, length = 100)
-	private String title;
-
-	@Column(name = "content", nullable = false, columnDefinition = "TEXT")
-	private String content;
-
 	@Column(name = "is_read", nullable = false)
 	private boolean isRead = false;
 
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 
-	private Notification(Long userId, Long targetUserId, NotificationType type, String title, String content) {
+	private Notification(Long userId, NotificationType type) {
 		this.userId = userId;
-		this.targetUserId = targetUserId;
 		this.type = type;
-		this.title = title;
-		this.content = content;
 		this.isRead = false;
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public static Notification create(
-		Long userId,
-		Long targetUserId,
-		NotificationType type,
-		String title,
-		String content
-	) {
-		return new Notification(userId, targetUserId, type, title, content);
+	private Notification(Long userId, Long targetUserId, NotificationType type) {
+		this.userId = userId;
+		this.targetUserId = targetUserId;
+		this.type = type;
+		this.isRead = false;
+		this.createdAt = LocalDateTime.now();
 	}
 
-	public static Notification create(Long userId, Long targetUserId, NotificationTemplate template) {
-		return new Notification(userId, targetUserId, template.type(), template.title(), template.content());
+	public static Notification create(Long userId, NotificationType type) {
+		return new Notification(userId, type);
+	}
+
+	public static Notification create(Long userId, Long targetUserId, NotificationType type) {
+		return new Notification(userId, targetUserId, type);
 	}
 
 	public void markAsRead() {
 		this.isRead = true;
-	}
-
-	public record NotificationTemplate(
-		NotificationType type,
-		String title,
-		String content
-	) {
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/repository/NotificationRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-	List<Notification> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+	List<Notification> findAllByUserIdOrderByCreatedAtAsc(Long userId);
 
 	long countByUserIdAndIsReadFalse(Long userId);
 

--- a/src/main/java/com/domisa/domisa_backend/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/repository/NotificationRepository.java
@@ -9,6 +9,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
 	List<Notification> findAllByUserIdOrderByCreatedAtAsc(Long userId);
 
+	List<Notification> findAllByUserIdAndIsCanceledFalseOrderByCreatedAtAsc(Long userId);
+
 	long countByUserIdAndIsReadFalse(Long userId);
 
 	Optional<Notification> findByIdAndUserId(Long notificationId, Long userId);

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import com.domisa.domisa_backend.notification.repository.NotificationRepository;
 import com.domisa.domisa_backend.notification.type.NotificationType;
 import com.domisa.domisa_backend.user.entity.User;
 import com.domisa.domisa_backend.user.repository.UserRepository;
+import com.domisa.domisa_backend.user.type.AnimalProfile;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -31,28 +32,34 @@ public class NotificationService {
 	@Transactional
 	public Notification createNotification(NotificationType type, Long userId, Long targetUserId) {
 		validateUserExists(userId);
-		if (targetUserId != null) {
+
+		Notification notification;
+		if (requiresTargetUser(type)) {
+			if (targetUserId == null) {
+				throw new GlobalException(GlobalErrorCode.MISSING_REQUIRED_FIELD);
+			}
 			validateUserExists(targetUserId);
+			notification = Notification.create(userId, targetUserId, type);
+		} else {
+			notification = Notification.create(userId, type);
 		}
 
-		Notification.NotificationTemplate template = createTemplate(type);
-		Notification notification = Notification.create(userId, targetUserId, template);
 		return notificationRepository.save(notification);
 	}
 
 	@Transactional(readOnly = true)
 	public NotificationListResponse getNotifications(Long userId) {
-		List<Notification> storedNotifications = notificationRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
-		Map<Long, String> publicIdsById = getPublicIdsById(storedNotifications);
+		List<Notification> storedNotifications = notificationRepository.findAllByUserIdOrderByCreatedAtAsc(userId);
+		Map<Long, User> usersById = getUsersById(storedNotifications);
 		List<NotificationListResponse.NotificationItem> notifications = storedNotifications
 			.stream()
 			.map(notification -> new NotificationListResponse.NotificationItem(
 				notification.getId(),
-				publicIdsById.get(notification.getUserId()),
-				publicIdsById.get(notification.getTargetUserId()),
+				getPublicId(usersById.get(notification.getUserId())),
 				notification.getType(),
-				notification.getTitle(),
-				notification.getContent(),
+				getPublicId(usersById.get(notification.getTargetUserId())),
+				getAnimalProfile(usersById.get(notification.getTargetUserId())),
+				getPersonNickname(usersById.get(notification.getTargetUserId())),
 				notification.isRead(),
 				notification.getCreatedAt()
 			))
@@ -76,25 +83,6 @@ public class NotificationService {
 		return new NotificationReadResponse(notification.getId(), notification.isRead());
 	}
 
-	private Notification.NotificationTemplate createTemplate(NotificationType type) {
-		return switch (type) {
-			case LIKE -> new Notification.NotificationTemplate(
-				NotificationType.LIKE,
-				"새로운 호감이 도착했어요",
-				"새로운 호감을 확인해보세요."
-			);
-			case INTRODUCTION -> new Notification.NotificationTemplate(
-				NotificationType.INTRODUCTION,
-				"소개서가 도착했어요",
-				"새로운 소개서를 확인해보세요."
-			);
-			case SHUFFLE -> new Notification.NotificationTemplate(
-				NotificationType.SHUFFLE,
-				"새로운 추천이 도착했어요",
-				"새로운 추천 상대를 확인해보세요."
-			);
-		};
-	}
 
 	private void validateUserExists(Long userId) {
 		if (!userRepository.existsById(userId)) {
@@ -102,7 +90,11 @@ public class NotificationService {
 		}
 	}
 
-	private Map<Long, String> getPublicIdsById(List<Notification> notifications) {
+	private boolean requiresTargetUser(NotificationType type) {
+		return type == NotificationType.LIKE || type == NotificationType.MATCH;
+	}
+
+	private Map<Long, User> getUsersById(List<Notification> notifications) {
 		Set<Long> userIds = new HashSet<>();
 		for (Notification notification : notifications) {
 			if (notification.getUserId() != null) {
@@ -118,6 +110,18 @@ public class NotificationService {
 		}
 
 		return userRepository.findAllByIdIn(userIds).stream()
-			.collect(Collectors.toMap(User::getId, User::getPublicId));
+			.collect(Collectors.toMap(User::getId, user -> user));
+	}
+
+	private String getPublicId(User user) {
+		return user == null ? null : user.getPublicId();
+	}
+
+	private AnimalProfile getAnimalProfile(User user) {
+		return user == null ? null : user.getAnimalProfile();
+	}
+
+	private String getPersonNickname(User user) {
+		return user == null ? null : user.getNickname();
 	}
 }

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -4,6 +4,7 @@ import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
 import com.domisa.domisa_backend.global.exception.GlobalException;
 import com.domisa.domisa_backend.notification.dto.NotificationListResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationSimpleListResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
 import com.domisa.domisa_backend.notification.entity.Notification;
 import com.domisa.domisa_backend.notification.repository.NotificationRepository;
@@ -66,6 +67,25 @@ public class NotificationService {
 			.toList();
 
 		return new NotificationListResponse(notifications);
+	}
+
+	@Transactional(readOnly = true)
+	public NotificationSimpleListResponse getActiveNotifications(Long userId) {
+		String publicUserId = userRepository.findById(userId)
+			.map(User::getPublicId)
+			.orElseThrow(() -> new GlobalException(GlobalErrorCode.USER_NOT_FOUND));
+
+		List<NotificationSimpleListResponse.NotificationItem> notifications = notificationRepository
+			.findAllByUserIdAndIsCanceledFalseOrderByCreatedAtAsc(userId)
+			.stream()
+			.map(notification -> new NotificationSimpleListResponse.NotificationItem(
+				notification.getId(),
+				publicUserId,
+				notification.getType()
+			))
+			.toList();
+
+		return new NotificationSimpleListResponse(notifications);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/service/NotificationService.java
@@ -3,9 +3,9 @@ package com.domisa.domisa_backend.notification.service;
 import com.domisa.domisa_backend.global.exception.GlobalErrorCode;
 import com.domisa.domisa_backend.global.exception.GlobalException;
 import com.domisa.domisa_backend.notification.dto.NotificationListResponse;
-import com.domisa.domisa_backend.notification.dto.NotificationReadResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationSimpleListResponse;
 import com.domisa.domisa_backend.notification.dto.NotificationStatusResponse;
+import com.domisa.domisa_backend.notification.dto.NotificationUpdateRequest;
 import com.domisa.domisa_backend.notification.entity.Notification;
 import com.domisa.domisa_backend.notification.repository.NotificationRepository;
 import com.domisa.domisa_backend.notification.type.NotificationType;
@@ -95,12 +95,11 @@ public class NotificationService {
 	}
 
 	@Transactional
-	public NotificationReadResponse markAsRead(Long userId, Long notificationId) {
-		Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+	public void updateNotification(Long userId, NotificationUpdateRequest request) {
+		Notification notification = notificationRepository.findByIdAndUserId(request.notificationId(), userId)
 			.orElseThrow(() -> new GlobalException(GlobalErrorCode.NOTIFICATION_NOT_FOUND));
 
-		notification.markAsRead();
-		return new NotificationReadResponse(notification.getId(), notification.isRead());
+		notification.updateStatus(request.isRead(), request.isClosed());
 	}
 
 

--- a/src/main/java/com/domisa/domisa_backend/notification/type/NotificationType.java
+++ b/src/main/java/com/domisa/domisa_backend/notification/type/NotificationType.java
@@ -1,7 +1,8 @@
 package com.domisa.domisa_backend.notification.type;
 
 public enum NotificationType {
-	LIKE, // 호감표시를 받음
-	INTRODUCTION, // 소개서 도착
-	SHUFFLE // 새로고침 가능
+	LIKE,       // 누군가 나에게 호감을 보냈을 때
+	MATCH,      // 쌍방 매칭이 이뤄졌을 때
+	SIGNUP,     // 회원가입 보상 쿠키가 지급되었을 때
+	REFERRAL    // 내가 초대한 친구가 가입해 쿠키가 지급되었을 때
 }


### PR DESCRIPTION
## 작업 내용
- 알림 목록 조회 응답 구조를 개편했습니다.
  - 기존 `title`, `content` 기반 응답을 제거했습니다.
  - 응답에 `targetUserId`, `animalProfile`, `personNickname`를 포함하도록 변경했습니다.
- 활성 상태의 알림만 조회하는 API를 추가했습니다.
  - `GET /notifications/active`
  - 취소되지 않은(`isCanceled = false`) 알림만 반환합니다.
- 알림 수정 API를 변경했습니다.
  - 기존: `POST /notifications/{notificationId}`
  - 변경: `POST /notifications`
  - 요청 바디로 `notificationId`, `isRead`, `isClosed`를 받아 읽음/닫힘 상태를 함께 갱신합니다.
  - 응답은 `204 No Content`로 변경했습니다.
- 알림 엔티티 구조를 정리했습니다.
  - `title`, `content` 필드를 제거했습니다.
  - `isCanceled` 필드를 추가했습니다.
  -  알림 상태 변경 메서드를 `updateStatus`로 통합했습니다.
- 알림 생성 로직을 정리했습니다.
  - 타입별로 target user 필요 여부를 분기하도록 수정했습니다.
  - `LIKE`, `MATCH`는 target user가 필수입니다.
- 알림 타입을 개편했습니다.
  - 제거: `INTRODUCTION`, `SHUFFLE`
  - 추가/변경: `MATCH`, `SIGNUP`, `REFERRAL`